### PR TITLE
Migrate NOAA pipeline to 1.1

### DIFF
--- a/pipelines/dax_noaa_weather_data/README.md
+++ b/pipelines/dax_noaa_weather_data/README.md
@@ -10,6 +10,10 @@ This pipeline illustrates the following concepts:
 
 ![pipeline snapshot](doc/images/pipeline_snapshot.png)
 
+ ## Prerequisites
+ 
+ This pipeline requires Elyra v1.1 or later.
+
  ## Exploring the pipeline
 
  1. [Configure a KubeFlow runtime environment in Elyra](https://elyra.readthedocs.io/en/latest/user_guide/runtime-conf.html) 

--- a/pipelines/dax_noaa_weather_data/analyze_NOAA_weather_data.pipeline
+++ b/pipelines/dax_noaa_weather_data/analyze_NOAA_weather_data.pipeline
@@ -13,7 +13,7 @@
           "type": "execution_node",
           "op": "execute-notebook-node",
           "app_data": {
-            "filename": "pipelines/dax_noaa_weather_data/load_data.ipynb",
+            "filename": "load_data.ipynb",
             "runtime_image": "amancevice/pandas:1.0.3",
             "env_vars": [
               "DATASET_URL=https://dax-cdn.cdn.appdomain.cloud/dax-noaa-weather-data-jfk-airport/1.1.4/noaa-weather-data-jfk-airport.tar.gz"
@@ -65,7 +65,7 @@
           "type": "execution_node",
           "op": "execute-notebook-node",
           "app_data": {
-            "filename": "pipelines/dax_noaa_weather_data/Part 1 - Data Cleaning.ipynb",
+            "filename": "Part 1 - Data Cleaning.ipynb",
             "runtime_image": "amancevice/pandas:1.0.3",
             "env_vars": [],
             "include_subdirectories": false,
@@ -115,7 +115,7 @@
           "type": "execution_node",
           "op": "execute-notebook-node",
           "app_data": {
-            "filename": "pipelines/dax_noaa_weather_data/Part 2 - Data Analysis.ipynb",
+            "filename": "Part 2 - Data Analysis.ipynb",
             "runtime_image": "amancevice/pandas:1.0.3",
             "env_vars": [],
             "include_subdirectories": false,
@@ -162,7 +162,7 @@
           "type": "execution_node",
           "op": "execute-notebook-node",
           "app_data": {
-            "filename": "pipelines/dax_noaa_weather_data/Part 3 - Time Series Forecasting.ipynb",
+            "filename": "Part 3 - Time Series Forecasting.ipynb",
             "runtime_image": "amancevice/pandas:1.0.3",
             "env_vars": [],
             "include_subdirectories": false,
@@ -270,7 +270,7 @@
             }
           ]
         },
-        "version": 1
+        "version": 2
       },
       "runtime_ref": ""
     }


### PR DESCRIPTION
The updated pipeline is now portable, meaning if the `.pipeline` file is moved to a new directory location along with its dependencies (notebooks, input artifacts) it will run without any changes as long as the relative path between the `.pipeline` file and its dependencies doesn't change.

Note: Due to the migration the pipeline file is no longer compatible with Elyra version < 1.1.