### PR TITLE
Add link to Elyra deployment options to hello_world tutorial

### DIFF
--- a/pipelines/hello_world/README.md
+++ b/pipelines/hello_world/README.md
@@ -10,7 +10,7 @@ A companion tutorial will cover how to run pipelines on Kubeflow Pipelines, enab
 
 ### Prerequisites
 
-- JupyterLab 2.x with the Elyra extension v1.1 (or newer) installed
+- JupyterLab 2.x with the Elyra extension v1.1 (or newer) installed. Refer to the Elyra repository for [deployment options](https://github.com/elyra-ai/elyra#try-elyra).
 
 ### Setup
 

--- a/pipelines/hello_world/README.md
+++ b/pipelines/hello_world/README.md
@@ -10,8 +10,7 @@ A companion tutorial will cover how to run pipelines on Kubeflow Pipelines, enab
 
 ### Prerequisites
 
-- JupyterLab 2.x with the Elyra extension v1.1 (or newer) installed. Refer to the Elyra repository for [deployment options](https://github.com/elyra-ai/elyra#try-elyra).
-
+- [JupyterLab 2.x with the Elyra extension v1.1 (or newer) installed](https://elyra.readthedocs.io/en/latest/getting_started/installation.html). 
 ### Setup
 
 This tutorial uses the `hello_world` sample from the https://github.com/elyra-ai/examples GitHub repository.


### PR DESCRIPTION
This PR adds a link to the Elyra deployment options to make it easier to get set up.