### PR TITLE
Add link to v2.2.x branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ limitations under the License.
 # Elyra examples
 
 This repository provides a set of examples that explore some of the unique
-features provided by Elyra.
+features provided by Elyra. All examples require Elyra version 2.3.x.
+
+Examples for earlier releases:
+ - [`v2.2.x`](https://github.com/elyra-ai/examples/tree/v2.2.x)
 
 ## AI/ML Pipelines
 


### PR DESCRIPTION
Elyra version 2.3 introduces many changes, requiring significant rework of existing examples. To preserve the existing examples a new branch was created that the documentation will link to.
This PR adds a link to a frozen branch containing the examples for version 2.2.x.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
