### PR TITLE
Add KFP custom component example for 'run notebook' 

### DIFF
--- a/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/README.md
+++ b/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/README.md
@@ -1,6 +1,6 @@
 ### Run notebook component
 
-Use the [_run notebook_ example component](https://github.com/elyra-ai/elyra/tree/master/elyra/pipeline/resources/kfp/run_notebook_using_papermill) to run a Jupyter notebook using [Papermill](https://papermill.readthedocs.io/en/latest/).
+Use the [_run notebook_ example component](https://github.com/elyra-ai/elyra/blob/master/etc/config/components/kfp/run_notebook_using_papermill.yaml) to run a Jupyter notebook using [Papermill](https://papermill.readthedocs.io/en/latest/).
 
 ### Prerequisites
 

--- a/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/README.md
+++ b/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/README.md
@@ -11,9 +11,9 @@ None. The example pipeline should work as is.
 - **Notebook** (required). The Jupyter notebook to run.
 - **Parameters** (optional, defaults to `{}` - no parameters). Parameters to be passed to the notebook.
 - **Packages to install** (optional, defaults to `[]` - no packages). Packages to be installed.
-- **Input data** (optional). If set, environment variable `INPUT_DATA_PATH` points to the location.
+- **Input data** (optional). If set, variable `INPUT_DATA_PATH` points to a file that contains the provided input data.
 
 ### Outputs
 
 - **Notebook**. The executed notebook.
-- **Output data**. `OUTPUT_DATA_PATH`
+- **Output data**. Variable `OUTPUT_DATA_PATH` points to a directory where the notebook can store output files.

--- a/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/README.md
+++ b/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/README.md
@@ -1,0 +1,19 @@
+### Run notebook component
+
+Use the [_run notebook_ example component](https://github.com/elyra-ai/elyra/tree/master/elyra/pipeline/resources/kfp/run_notebook_using_papermill) to run a Jupyter notebook using [Papermill](https://papermill.readthedocs.io/en/latest/).
+
+### Prerequisites
+
+None. The example pipeline should work as is.
+
+### Parameters
+
+- **Notebook** (required). The Jupyter notebook to run.
+- **Parameters** (optional, defaults to `{}` - no parameters). Parameters to be passed to the notebook.
+- **Packages to install** (optional, defaults to `[]` - no packages). Packages to be installed.
+- **Input data** (optional). If set, environment variable `INPUT_DATA_PATH` points to the location.
+
+### Outputs
+
+- **Notebook**. The executed notebook.
+- **Output data**. `OUTPUT_DATA_PATH`

--- a/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/a-notebook.ipynb
+++ b/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/a-notebook.ipynb
@@ -32,7 +32,8 @@
    "outputs": [],
    "source": [
     "# this cell is tagged with \"parameters\"\n",
-    "data_url = 'https://raw.githubusercontent.com/ptitzler/kfp-component-tests/main/component_definitions/download-file/tests/data-file.csv'\n",
+    "# Dummy data URL\n",
+    "data_url = 'https://raw.githubusercontent.com/elyra-ai/examples/master/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/data/data-2.csv'\n",
     "multiplier = 1\n",
     "INPUT_DATA_PATH = None\n",
     "OUTPUT_DATA_PATH = None"

--- a/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/a-notebook.ipynb
+++ b/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/a-notebook.ipynb
@@ -1,19 +1,104 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "698c1153-b00b-4149-bb3d-3d15b3efbe4a",
+   "metadata": {},
+   "source": [
+    "This example notebook reads a CSV file, manipulates the data, and stores the updated data. It is assumed that the second column contains a numeric value."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "985ca2ff-c0e9-4f80-bb3f-603dc71279b5",
+   "id": "cfc85233-db10-4145-91c2-e9077ac0e969",
    "metadata": {},
    "outputs": [],
    "source": [
-    "print('Hello from the notebook')"
+    "import os\n",
+    "import pandas as pd\n",
+    "from urllib.parse import urlparse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e60eac5-fd86-47cd-bd07-abdd3023d9d0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# this cell is tagged with \"parameters\"\n",
+    "data_url = 'https://raw.githubusercontent.com/ptitzler/kfp-component-tests/main/component_definitions/download-file/tests/data-file.csv'\n",
+    "multiplier = 1\n",
+    "INPUT_DATA_PATH = None\n",
+    "OUTPUT_DATA_PATH = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "824ee8ad-4bd4-47ef-8c4c-c141c9df1606",
+   "metadata": {},
+   "source": [
+    "Download the [assumed] CSV file from data_url, multiply the second column (which is assumed to be a numeric) with the value of variable multiplier. Store the modified DataFrame under a different filename."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf9fdd36-4ef9-4ae9-9762-43c789626104",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'Downloading {data_url} ...')\n",
+    "\n",
+    "df = pd.read_csv(data_url, header=None)\n",
+    "print('Data preview:')\n",
+    "print(df.head())\n",
+    "\n",
+    "print('Manipulating data frame ...')\n",
+    "df[1] = df[1] * multiplier\n",
+    "\n",
+    "\n",
+    "if OUTPUT_DATA_PATH is not None:\n",
+    "    parsed_url = urlparse(data_url)\n",
+    "    filename = os.path.splitext(os.path.basename(parsed_url.path))[0]\n",
+    "    extension = os.path.splitext(os.path.basename(parsed_url.path))[1]\n",
+    "    output_filename = os.path.join(OUTPUT_DATA_PATH, f'{filename}-out{extension}')\n",
+    "    print(f'Saving modified DataFrame as {output_filename} ...')\n",
+    "    df.to_csv(output_filename, index=False, header=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61048214-f946-4c7c-a038-c5e3d6567b51",
+   "metadata": {},
+   "source": [
+    "Print the content of INPUT_DATA_PATH, if one was provided"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a45f4fe7-eccc-44fe-952d-8524fa205b58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if INPUT_DATA_PATH is not None:\n",
+    "    print(f'Input data is stored in {INPUT_DATA_PATH}')\n",
+    "    with open(INPUT_DATA_PATH, 'r') as input_data:\n",
+    "        data = input_data.read()\n",
+    "        print('Input data:')\n",
+    "        print(data)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/a-notebook.ipynb
+++ b/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/a-notebook.ipynb
@@ -1,0 +1,35 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "985ca2ff-c0e9-4f80-bb3f-603dc71279b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Hello from the notebook')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/data/data-1.csv
+++ b/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/data/data-1.csv
@@ -1,0 +1,7 @@
+line1,1
+line2,2
+line3,3
+line4,4
+line5,5
+line6,6
+line7,7

--- a/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/data/data-2.csv
+++ b/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/data/data-2.csv
@@ -1,0 +1,9 @@
+row1,9
+row2,8
+row3,7
+row4,6
+row5,5
+row6,4
+row7,3
+row8,2
+row9,1

--- a/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/run_notebook_using_papermill.pipeline
+++ b/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/run_notebook_using_papermill.pipeline
@@ -1,0 +1,93 @@
+{
+  "doc_type": "pipeline",
+  "version": "3.0",
+  "json_schema": "http://api.dataplatform.ibm.com/schemas/common-pipeline/pipeline-flow/pipeline-flow-v3-schema.json",
+  "id": "elyra-auto-generated-pipeline",
+  "primary_pipeline": "primary",
+  "pipelines": [
+    {
+      "id": "primary",
+      "nodes": [
+        {
+          "id": "0eddd672-6ca5-4ff6-a230-c60562384892",
+          "type": "execution_node",
+          "op": "run-notebook-using-papermill",
+          "app_data": {
+            "component_parameters": {
+              "notebook": "a-notebook.ipynb",
+              "parameters": "{}",
+              "packages_to_install": "[]",
+              "input_data": ""
+            },
+            "label": "",
+            "component_source": "kfp/run_notebook_using_papermill/component.yaml",
+            "ui_data": {
+              "label": "Run notebook using papermill",
+              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20276.93%20274.55%22%3E%3Cg%20id%3D%22Layer_2%22%20data-name%3D%22Layer%202%22%3E%3Cg%20id%3D%22Layer_1-2%22%20data-name%3D%22Layer%201%22%3E%3Cpath%20d%3D%22M95.9%2C62.15%2C100%2C164.25l73.75-94.12a6.79%2C6.79%2C0%2C0%2C1%2C9.6-1.11l46%2C36.92-15-65.61Z%22%20fill%3D%22%234279f4%22%2F%3E%3Cpolygon%20points%3D%22102.55%20182.98%20167.97%20182.98%20127.8%20150.75%20102.55%20182.98%22%20fill%3D%22%230028aa%22%2F%3E%3Cpolygon%20points%3D%22180.18%2083.92%20136.18%20140.06%20183.06%20177.67%20227.53%20121.91%20180.18%2083.92%22%20fill%3D%22%23014bd1%22%2F%3E%3Cpolygon%20points%3D%2283.56%2052.3%2083.57%2052.29%20122.26%203.77%2059.87%2033.82%2044.46%20101.33%2083.56%2052.3%22%20fill%3D%22%23bedcff%22%2F%3E%3Cpolygon%20points%3D%2245.32%20122.05%2086.76%20174.01%2082.81%2075.03%2045.32%20122.05%22%20fill%3D%22%236ca1ff%22%2F%3E%3Cpolygon%20points%3D%22202.31%2028.73%20142.65%200%20105.52%2046.56%20202.31%2028.73%22%20fill%3D%22%23a1c3ff%22%2F%3E%3Cpath%20d%3D%22M1.6%2C272V227.22H7.34v23.41l20.48-23.41h6.4l-17.39%2C19.7%2C19%2C25.07H29.1l-15.92-20.8-5.84%2C6.65V272Z%22%20fill%3D%22%234279f4%22%20stroke%3D%22%234279f4%22%20stroke-miterlimit%3D%2210%22%20stroke-width%3D%223.2%22%2F%3E%3Cpath%20d%3D%22M41.62%2C262.21V240h5.43v22.39a4.67%2C4.67%2C0%2C0%2C0%2C2.35%2C4.19%2C11%2C11%2C0%2C0%2C0%2C11%2C0%2C4.69%2C4.69%2C0%2C0%2C0%2C2.33-4.19V240h5.43v22.19a9.08%2C9.08%2C0%2C0%2C1-4.1%2C7.87%2C16.2%2C16.2%2C0%2C0%2C1-18.37%2C0A9.07%2C9.07%2C0%2C0%2C1%2C41.62%2C262.21Z%22%20fill%3D%22%234279f4%22%20stroke%3D%22%234279f4%22%20stroke-miterlimit%3D%2210%22%20stroke-width%3D%223.2%22%2F%3E%3Cpath%20d%3D%22M77.46%2C272V224h5.43v16.81a29.29%2C29.29%2C0%2C0%2C1%2C9.32-1.73%2C13.1%2C13.1%2C0%2C0%2C1%2C6.2%2C1.41%2C10.71%2C10.71%2C0%2C0%2C1%2C4.18%2C3.74%2C18.07%2C18.07%2C0%2C0%2C1%2C2.23%2C5.06%2C21.26%2C21.26%2C0%2C0%2C1%2C.73%2C5.58q0%2C8.43-4.38%2C12.79T87.35%2C272Zm5.43-4.87h4.55q6.77%2C0%2C9.72-2.95t3-9.51a14.21%2C14.21%2C0%2C0%2C0-2-7.52%2C6.55%2C6.55%2C0%2C0%2C0-6-3.22%2C24.73%2C24.73%2C0%2C0%2C0-9.25%2C1.54Z%22%20fill%3D%22%234279f4%22%20stroke%3D%22%234279f4%22%20stroke-miterlimit%3D%2210%22%20stroke-width%3D%223.2%22%2F%3E%3Cpath%20d%3D%22M112.36%2C255.94q0-7.71%2C4.09-12.3a13.75%2C13.75%2C0%2C0%2C1%2C10.8-4.59q13.35%2C0%2C13.36%2C18.86H117.79a12.3%2C12.3%2C0%2C0%2C0%2C2.9%2C7.07q2.59%2C3.11%2C7.9%2C3.1a24.92%2C24.92%2C0%2C0%2C0%2C10.55-2v5a27.74%2C27.74%2C0%2C0%2C1-9.86%2C1.87%2C19.83%2C19.83%2C0%2C0%2C1-7.7-1.37%2C13.31%2C13.31%2C0%2C0%2C1-5.28-3.76%2C16.21%2C16.21%2C0%2C0%2C1-3-5.38A20.84%2C20.84%2C0%2C0%2C1%2C112.36%2C255.94Zm5.62-2.12h17.26a14.91%2C14.91%2C0%2C0%2C0-2.37-7.12%2C6.44%2C6.44%2C0%2C0%2C0-5.62-2.78%2C8.2%2C8.2%2C0%2C0%2C0-6.21%2C2.72A12.07%2C12.07%2C0%2C0%2C0%2C118%2C253.82Z%22%20fill%3D%22%234279f4%22%20stroke%3D%22%234279f4%22%20stroke-miterlimit%3D%2210%22%20stroke-width%3D%223.2%22%2F%3E%3Cpath%20d%3D%22M147.32%2C244.89V240h5v-7.59a8.14%2C8.14%2C0%2C0%2C1%2C2.31-6.05%2C7.79%2C7.79%2C0%2C0%2C1%2C5.69-2.28h7.86V229h-5c-2.21%2C0-3.67.45-4.37%2C1.34s-1.06%2C2.55-1.06%2C5V240h8.46v4.87h-8.46V272h-5.44v-27.1Z%22%20fill%3D%22%230028aa%22%20stroke%3D%22%230028aa%22%20stroke-miterlimit%3D%2210%22%20stroke-width%3D%223.2%22%2F%3E%3Cpath%20d%3D%22M175.26%2C272V224h5.43v48Z%22%20fill%3D%22%230028aa%22%20stroke%3D%22%230028aa%22%20stroke-miterlimit%3D%2210%22%20stroke-width%3D%223.2%22%2F%3E%3Cpath%20d%3D%22M194.41%2C268.05a17.86%2C17.86%2C0%2C1%2C1%2C12.33%2C4.9A16.57%2C16.57%2C0%2C0%2C1%2C194.41%2C268.05Zm3.84-20.65a13.16%2C13.16%2C0%2C0%2C0%2C0%2C17.2%2C12.07%2C12.07%2C0%2C0%2C0%2C17%2C0%2C13.09%2C13.09%2C0%2C0%2C0%2C0-17.2%2C12.07%2C12.07%2C0%2C0%2C0-17%2C0Z%22%20fill%3D%22%230028aa%22%20stroke%3D%22%230028aa%22%20stroke-miterlimit%3D%2210%22%20stroke-width%3D%223.2%22%2F%3E%3Cpath%20d%3D%22M228.45%2C240h5.75l7.3%2C25.32L248.93%2C240h5.36l7.34%2C25.34L269%2C240h5.74L264.7%2C272h-6.12l-6.83-24.58L245%2C272h-6.47Z%22%20fill%3D%22%230028aa%22%20stroke%3D%22%230028aa%22%20stroke-miterlimit%3D%2210%22%20stroke-width%3D%223.2%22%2F%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E",
+              "x_pos": 163,
+              "y_pos": 125.50000762939453,
+              "description": "Run Jupyter notebook using papermill. The notebook will receive the parameter values passed to it as well as the INPUT_DATA_PATH and OUTPUT_DATA_PATH variables that will be set to the input data path (if provided) and directory for the optional output data."
+            }
+          },
+          "inputs": [
+            {
+              "id": "inPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Input Port"
+                }
+              }
+            }
+          ],
+          "outputs": [
+            {
+              "id": "outPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Output Port"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "app_data": {
+        "ui_data": {
+          "comments": [
+            {
+              "id": "1a5d78a6-be2a-417f-8aaa-8dfb8917e170",
+              "x_pos": 30,
+              "y_pos": 30,
+              "width": 332,
+              "height": 59,
+              "class_name": "d3-comment-rect",
+              "content": "Run the specified notebook using papermill",
+              "associated_id_refs": [
+                {
+                  "node_ref": "0eddd672-6ca5-4ff6-a230-c60562384892"
+                }
+              ]
+            }
+          ]
+        },
+        "version": 4,
+        "runtime": "kfp",
+        "properties": {
+          "name": "run_notebook_using_papermill",
+          "runtime": "Kubeflow Pipelines",
+          "description": "Example pipeline for the 'run notebook using papermill' custom component."
+        }
+      },
+      "runtime_ref": ""
+    }
+  ],
+  "schemas": []
+}

--- a/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/run_notebook_using_papermill.pipeline
+++ b/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/run_notebook_using_papermill.pipeline
@@ -15,9 +15,9 @@
           "app_data": {
             "component_parameters": {
               "notebook": "a-notebook.ipynb",
-              "parameters": "{'multiplier':2}",
+              "parameters": "{'multiplier':2, 'data_url': 'https://raw.githubusercontent.com/elyra-ai/examples/master/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/data/data-1.csv'}",
               "packages_to_install": "['pandas']",
-              "input_data": "earth to notebook"
+              "input_data": "some string data"
             },
             "label": "",
             "component_source": "kfp/run_notebook_using_papermill/component.yaml",

--- a/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/run_notebook_using_papermill.pipeline
+++ b/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/run_notebook_using_papermill.pipeline
@@ -15,9 +15,9 @@
           "app_data": {
             "component_parameters": {
               "notebook": "a-notebook.ipynb",
-              "parameters": "{}",
-              "packages_to_install": "[]",
-              "input_data": ""
+              "parameters": "{'multiplier':2}",
+              "packages_to_install": "['pandas']",
+              "input_data": "earth to notebook"
             },
             "label": "",
             "component_source": "kfp/run_notebook_using_papermill/component.yaml",
@@ -66,10 +66,10 @@
               "id": "1a5d78a6-be2a-417f-8aaa-8dfb8917e170",
               "x_pos": 30,
               "y_pos": 30,
-              "width": 332,
+              "width": 249,
               "height": 59,
               "class_name": "d3-comment-rect",
-              "content": "Run the specified notebook using papermill",
+              "content": "Run the parametrized notebook using papermill",
               "associated_id_refs": [
                 {
                   "node_ref": "0eddd672-6ca5-4ff6-a230-c60562384892"


### PR DESCRIPTION
This PR
  - documents the 'run notebook' custom KFP component
 
TODO:

- [x] Add dependency on `Pandas`
- [x] Add data file
- [x] Use input data file
- [x] Generate output file

Verified:
- [x] Pipeline works without any changes
- [x] Pipeline version 4
- [x] Pipeline description 


Notes:
- The pipeline (and notebook) will not work as is until the PR is merged because both are referencing data files that this PR delivers. 
- To work around the issue, replace this `data_url` parameter 

![image](https://user-images.githubusercontent.com/13068832/127353980-66bd98d5-5163-4bf9-9f73-18869267f328.png)

  with 
```
https://raw.githubusercontent.com/ptitzler/examples/document-run-notebook-component/pipelines/kubeflow_pipelines_component_examples/run_notebook_component/data/data-1.csv
```


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
