### PR TITLE
Fix pathname typo in 'Introduction to Generic Pipelines' Readme

### DIFF
--- a/pipelines/introduction-to-generic-pipelines/README.md
+++ b/pipelines/introduction-to-generic-pipelines/README.md
@@ -45,7 +45,7 @@ This tutorial uses the `introduction to generic components` sample from the http
 1. Launch JupyterLab.
 1. Open the _Git clone_ wizard (Git > Clone A Repository).
 1. Enter `https://github.com/elyra-ai/examples.git` as _Clone URI_.
-1. In the _File Browser_ navigate to `examples/pipelines/introduction-to-generic-components`.
+1. In the _File Browser_ navigate to `examples/pipelines/introduction-to-generic-pipelines`.
 
    ![Tutorial assets in File Browser](doc/images/tutorial-directory.png)
    


### PR DESCRIPTION
changed 'introduction-to-generic-components' to 'introduction-to-generic-pipelines' for correct path



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
