### PR TITLE
Deprecate Apache Airflow example components catalog connector

### DIFF
--- a/component-catalog-connectors/airflow-example-components-connector/README.md
+++ b/component-catalog-connectors/airflow-example-components-connector/README.md
@@ -1,5 +1,16 @@
 [![PyPI version](https://badge.fury.io/py/elyra-examples-airflow-catalog.svg)](https://badge.fury.io/py/elyra-examples-airflow-catalog)
 
+
+## This connector is deprecated
+
+February 2022:
+ - The example operators that this connector provides will no longer be updated. 
+ - Please upgrade Elyra to version 3.6 (or above). 
+ - Use the [catalog connector for Apache Airflow packages](https://github.com/elyra-ai/elyra/tree/master/elyra/pipeline/airflow/package_catalog_connector) to add Apache Airflow built-in operators to your visual pipeline editor.
+ - Use the [catalog connector for Apache Airflow provider packages](https://github.com/elyra-ai/elyra/tree/master/elyra/pipeline/airflow/provider_package_catalog_connector) to add Apache Airflow [community provider](https://airflow.apache.org/docs/apache-airflow-providers/) operators to your visual pipeline editor.
+
+---
+
 ## Apache Airflow component examples catalog
 
 This catalog connector provides access to example pipeline components for Apache Airflow.


### PR DESCRIPTION
This PR adds a deprecation message to the Apache Airflow example components catalog connector.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
