### PR TITLE
Update catalog connector template to use new connector API

### DIFF
--- a/component-catalog-connectors/build-a-custom-connector.md
+++ b/component-catalog-connectors/build-a-custom-connector.md
@@ -17,7 +17,7 @@ The Elyra examples repository includes two types of catalog connectors:
 
    ![package-based catalog connector](doc/images/package-based-catalog-connector.png)
 
-   The [Apache Airflow component examples connector](airflow-example-components-connector/) and the [Kubeflow Pipelines component examples connector](kfp-example-components-connector/) are two examples. Each connector provides a static set components for each respective runtime.
+   The [Kubeflow Pipelines component examples connector](kfp-example-components-connector/) is an example of this type of catalog. Each connector provides a static set components for each respective runtime.
 
 Irrespective of which type of connector you plan to implement, you need to complete the following tasks:
  - create a catalog connector schema
@@ -27,11 +27,11 @@ Irrespective of which type of connector you plan to implement, you need to compl
 
 To get you started quickly with catalog connector development, the Elyra examples repository includes [quickstart catalog connector template files](connector-template/), which are referenced in the instructions below.
 
-The quickstart connector contains a built-in catalog, which contains only a single component. The aforementioned Kubeflow Pipelines and Apache Airflow component examples connectors are more flexible versions of this connector, which can serve many components.
+The quickstart connector contains a built-in catalog, which contains only a single component. The aforementioned Kubeflow Pipelines example connector is a more flexible version of this connector, which can serve many components.
 
 ### Prepare for development
 
-1. Install Elyra version 3.3 or later from PyPI or source.
+1. Install Elyra version 3.7 or later from PyPI or source.
 1. Clone or fork the [Elyra examples repository](https://github.com/elyra-ai/examples).
 1. Change into the `component-catalog-connectors/connector-template` directory. The directory contains a fully functional connector implementation that can be customized to meet your needs.
 1. Verify that the quickstart template connector works as expected by completing the [installation and usage instructions in the README](/component-catalog-connectors/connector-template/README.md).
@@ -47,9 +47,9 @@ The common public properties are:
  - catalog instance name
  - catalog instance description
  - runtime type filter, which governs the kind of components the connector makes available
- - component categories, which group the components together in the pipeline editor
+ - component categories, which group the components together in the pipeline editor palette
 
-Connector schemas can optionally also include custom public properties. For illustrative purposes, the quickstart template connector defines a required custom property and an optional custom property. Required properties are typically used to collect catalog connectivity information, such as a server URL, or API token. 
+Connector schemas can optionally also include custom public properties. For illustrative purposes, the quickstart template connector defines a required custom property and an optional custom property. Required properties are typically used to collect catalog connectivity information, such as a server URL or API token. 
 
 #### Customize the schema
 
@@ -97,7 +97,7 @@ Example `SchemasProvider` implementations:
 A catalog connector class implements the API that Elyra uses to query the component catalog and retrieve components. The quickstart connector class source code `todo_catalog_connector.py` is located in the [`todo_catalog_connector`](connector-template/todo_catalog_connector) directory.
 
 1. Customize the class name.
-1. Implement the `get_catalog_entries`, `read_catalog_entry`, and `get_hash_keys` methods.
+1. Implement the `get_catalog_entries`, `get_entry_data`, and `get_hash_keys` methods.
 
 Example catalog connector implementations:
  - [Kubeflow Pipelines example components connector](/component-catalog-connectors/kfp-example-components-connector/kfp_examples_connector/examples_connector.py)
@@ -208,7 +208,7 @@ The JupyterLab log file should include an error message that explains what happe
     No definition content found for catalog entry with identifying information: {'...': '...'}. Skipping... 
     ```
 
-    Action: The connector implementation class's `read_catalog_entry` method did not return a component for the provided identifying information. This identifying information was returned by the connector implementation class's `get_catalog_entries` method. Make sure that the information is correct and that the component exists in the catalog.
+    Action: The connector implementation class's `get_entry_data` method did not return an `EntryData` object or the returned object did not include a component definition for the provided identifying information. This identifying information was returned by the connector implementation class's `get_catalog_entries` method. Make sure that the information is correct and that the component exists in the catalog.
 
 
 

--- a/component-catalog-connectors/connector-template/todo_catalog_connector/todo_catalog_connector.py
+++ b/component-catalog-connectors/connector-template/todo_catalog_connector/todo_catalog_connector.py
@@ -21,6 +21,7 @@ from typing import List
 from typing import Optional
 
 from elyra.pipeline.catalog_connector import ComponentCatalogConnector
+from elyra.pipeline.catalog_connector import EntryData
 
 """
  Customize this template file as necessary. At a minimum all occurrences
@@ -61,7 +62,7 @@ class TODOComponentCatalogConnector(ComponentCatalogConnector):
 
             # Fetch components and add their keys to the component list.
             # Each 'todo_component_key_info' uniquely identifies a component in the catalog.
-            # Method read_catalog_entry has access to todo_component_key_info via the
+            # Method get_entry_data has access to todo_component_key_info via the
             # 'catalog_entry_data' parameter and uses it to retrieve the component from the catalog.
             todo_component_key_info = {
                 'TODO-COMPONENT-KEY': 'dummy-component.yaml'
@@ -75,18 +76,20 @@ class TODOComponentCatalogConnector(ComponentCatalogConnector):
 
         return component_list
 
-    def read_catalog_entry(self,
-                           catalog_entry_data: Dict[str, Any],
-                           catalog_metadata: Dict[str, Any]) -> Optional[str]:
+    def get_entry_data(self,
+                       catalog_entry_data: Dict[str, Any],
+                       catalog_metadata: Dict[str, Any]) -> Optional[EntryData]:
         """
-        Fetch the component that is identified by catalog_entry_data from
-        the <TODO> catalog.
+        Fetch the definition that is identified by catalog_entry_data for the <TODO> catalog and
+        create an EntryData object to represent it. If runtime-type-specific properties are required
+        (e.g. `package_name` for certain Airflow operators), a runtime-type-specific EntryData
+        object can be created, e.g. AirflowEntryData(definition=<...>, package_name=<...>)
 
         :param catalog_entry_data: a dictionary that contains the information needed to read the content
-                                   of the component definition
+            of the component definition
         :param catalog_metadata: the metadata associated with the catalog in which this catalog entry is
-                                 stored; in addition to catalog_entry_data, catalog_metadata may also be
-                                 needed to read the component definition for certain types of catalogs
+            stored; in addition to catalog_entry_data, catalog_metadata may also be needed to read the
+            component definition for certain types of catalogs
 
         :returns: the content of the given catalog entry's definition in string form
         """
@@ -113,13 +116,14 @@ class TODOComponentCatalogConnector(ComponentCatalogConnector):
         self.log.debug(f'Fetching component from {component_source}')
         with open(component_source, 'r') as dummy_component_fp:
             # read and return component
-            return dummy_component_fp.read()
+            return EntryData(definition=dummy_component_fp.read())
 
         return None
 
-    def get_hash_keys(self) -> List[Any]:
+    @classmethod
+    def get_hash_keys(cls) -> List[Any]:
         """
-        Identifies the unique TODO catalog key that method read_catalog_entry
+        Identifies the unique TODO catalog key that method get_entry_data
         can use to fetch a component from the catalog. Method get_catalog_entries
         retrieves the list of available key values from the catalog.
 

--- a/component-catalog-connectors/connector-template/todo_catalog_connector/todo_catalog_connector.py
+++ b/component-catalog-connectors/connector-template/todo_catalog_connector/todo_catalog_connector.py
@@ -91,7 +91,7 @@ class TODOComponentCatalogConnector(ComponentCatalogConnector):
             stored; in addition to catalog_entry_data, catalog_metadata may also be needed to read the
             component definition for certain types of catalogs
 
-        :returns: the content of the given catalog entry's definition in string form
+        :returns: An instance of EntryData, if the referenced catalog_entry_data was found
         """
 
         # Load user-provided catalog connector parameters.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/master/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/master/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
Changes the `read_catalog_entry` function to a `get_entry_data` function for the catalog connector template in order to bring it in line with the changes from https://github.com/elyra-ai/elyra/pull/2492. The template connector currently returns a generic `EntryData` object, but there is an opportunity to create runtime-type-specific objects according to the runtime type of the catalog being parsed (although any `AirflowEntryData` objects will not include the `package_name` field so differentiating may not be strictly necessary).

Documentation has also been updated to reference the new implementation.

### How was this pull request tested?
No updates required.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
